### PR TITLE
fix: add public player pause/resume API

### DIFF
--- a/docs/assets/guide/en/tutorial_docs/VStory_Concepts/story-player.md
+++ b/docs/assets/guide/en/tutorial_docs/VStory_Concepts/story-player.md
@@ -130,4 +130,23 @@ player.play(1);
 player.play(-1);
 ```
 
+The `Player` also exposes public playback controls and state, so you no longer need to access private fields for pause or progress tracking.
+
+```ts
+player.pause();
+player.resume();
+
+console.log(player.state); // 'idle' | 'playing' | 'paused' | 'ended'
+console.log(player.currentTime);
+console.log(player.totalTime);
+
+player.on('stateChange', event => {
+  console.log(event.state, event.previousState);
+});
+
+player.on('end', event => {
+  console.log('playback finished', event.currentTime, event.totalTime);
+});
+```
+
 That's all for the definitions of `story` and `player`. You can try it out yourself or make changes in the [examples](/vstory/examples) to see how it works.

--- a/docs/assets/guide/zh/tutorial_docs/VStory_Concepts/story-player.md
+++ b/docs/assets/guide/zh/tutorial_docs/VStory_Concepts/story-player.md
@@ -130,4 +130,23 @@ player.play(1);
 player.play(-1);
 ```
 
+`Player` 现在也提供了公开的播放控制和状态查询接口，不需要再访问私有字段来暂停播放或监听进度。
+
+```ts
+player.pause();
+player.resume();
+
+console.log(player.state); // 'idle' | 'playing' | 'paused' | 'ended'
+console.log(player.currentTime);
+console.log(player.totalTime);
+
+player.on('stateChange', event => {
+  console.log(event.state, event.previousState);
+});
+
+player.on('end', event => {
+  console.log('playback finished', event.currentTime, event.totalTime);
+});
+```
+
 到这里，`story`和`player`的定义就介绍完了，大家可以自己动手试一下，或者去[examples](/vstory/examples)里去改一改试一试。

--- a/packages/vstory-core/__tests__/unit/index.test.ts
+++ b/packages/vstory-core/__tests__/unit/index.test.ts
@@ -167,4 +167,34 @@ describe('Player', () => {
     expect(endEvents).toEqual([{ currentTime: 100, totalTime: 100 }]);
     expect(ticker.getListenerCount('tick')).toBe(0);
   });
+
+  it('should restart story and scheduler state when play is called after pause or end', () => {
+    const { story } = createStory();
+    const actionProcessor = createActionProcessor();
+    const player = new Player(story, { actionProcessor });
+    (story.reset as jest.Mock).mockImplementation(() => player.reset());
+    player.initActions(createActions());
+
+    player.play(0);
+    ticker.emit('tick', 50);
+
+    player.pause();
+    expect(player.state).toBe('paused');
+
+    player.play(0);
+    expect(story.reset).toHaveBeenCalledTimes(1);
+    ticker.emit('tick', 100);
+
+    expect(player.state).toBe('ended');
+    expect(actionProcessor.applyAppearAttrs).toHaveBeenCalledTimes(2);
+    expect(actionProcessor.doAction).toHaveBeenCalledTimes(4);
+
+    player.play(0);
+    expect(story.reset).toHaveBeenCalledTimes(2);
+    ticker.emit('tick', 100);
+
+    expect(player.state).toBe('ended');
+    expect(actionProcessor.applyAppearAttrs).toHaveBeenCalledTimes(3);
+    expect(actionProcessor.doAction).toHaveBeenCalledTimes(6);
+  });
 });

--- a/packages/vstory-core/__tests__/unit/index.test.ts
+++ b/packages/vstory-core/__tests__/unit/index.test.ts
@@ -1,5 +1,170 @@
-describe('VChart Editor', () => {
-  it('should get the correct version', () => {
-    expect(1).toBeDefined();
+import { Player } from '../../src/core/player';
+import { globalTickerStore } from '../../src/tools/global-ticker';
+import type { IActionProcessor } from '../../src/interface/action-processor';
+import type { IActionSpec, IActSpec } from '../../src/interface/dsl/dsl';
+import type { IStory } from '../../src/interface/story';
+
+class FakeTicker {
+  listeners = new Map<string, Set<(delta?: number) => void>>();
+  start = jest.fn();
+  getTimelines = jest.fn(() => [{ clear: jest.fn() }]);
+
+  addListener(event: string, handler: (delta?: number) => void) {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event).add(handler);
+  }
+
+  removeListener(event: string, handler: (delta?: number) => void) {
+    this.listeners.get(event)?.delete(handler);
+  }
+
+  emit(event: string, delta?: number) {
+    this.listeners.get(event)?.forEach(handler => handler(delta));
+  }
+
+  getListenerCount(event: string) {
+    return this.listeners.get(event)?.size ?? 0;
+  }
+}
+
+function createAction(action: string, startTime: number, duration: number): IActionSpec {
+  return {
+    action,
+    startTime,
+    payload: {
+      animation: {
+        duration
+      }
+    }
+  };
+}
+
+function createActions(duration: number = 100): IActSpec[] {
+  return [
+    {
+      id: 'act-1',
+      scenes: [
+        {
+          id: 'scene-1',
+          actions: [
+            {
+              characterId: 'character-1',
+              characterActions: [createAction('appear', 0, 0), createAction('move', 0, duration)]
+            }
+          ]
+        }
+      ]
+    }
+  ];
+}
+
+function createActionProcessor(): IActionProcessor {
+  return {
+    getActInfo: jest.fn((characterId: string, action: IActionSpec) => ({
+      startTime: action.startTime ?? 0,
+      duration: (Array.isArray(action.payload) ? action.payload[0] : action.payload)?.animation?.duration ?? 0
+    })),
+    getProcessorList: jest.fn(),
+    getProcessor: jest.fn(),
+    doAction: jest.fn(),
+    applyAppearAttrs: jest.fn(),
+    release: jest.fn()
+  } as unknown as IActionProcessor;
+}
+
+function createStory() {
+  const character = {
+    config: { type: 'text' },
+    tickTo: jest.fn()
+  };
+  const story = {
+    reset: jest.fn(),
+    getCharacterById: jest.fn(() => character),
+    getCharacterList: jest.fn(() => [character]),
+    canvas: {
+      tickTo: jest.fn()
+    }
+  } as unknown as IStory;
+
+  return {
+    story,
+    character
+  };
+}
+
+describe('Player', () => {
+  let ticker: FakeTicker;
+
+  beforeEach(() => {
+    ticker = new FakeTicker();
+    jest.spyOn(globalTickerStore, 'getGlobalTicker').mockReturnValue(ticker as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should pause and resume playback without relying on private fields', () => {
+    const { story, character } = createStory();
+    const actionProcessor = createActionProcessor();
+    const player = new Player(story, { actionProcessor });
+    (story.reset as jest.Mock).mockImplementation(() => player.reset());
+    player.initActions(createActions(200));
+
+    const stateEvents: string[] = [];
+    player.on('stateChange', event => stateEvents.push(event.state));
+
+    const nowSpy = jest.spyOn(Date, 'now');
+    nowSpy.mockReturnValueOnce(1000).mockReturnValueOnce(1100).mockReturnValueOnce(1600).mockReturnValueOnce(1650);
+
+    player.play(0);
+    expect(player.state).toBe('playing');
+    expect(player.totalTime).toBe(200);
+    expect(ticker.getListenerCount('tick')).toBe(1);
+
+    ticker.emit('tick');
+    ticker.emit('tick');
+
+    expect(player.currentTime).toBe(100);
+
+    player.pause();
+    expect(player.state).toBe('paused');
+    expect(ticker.getListenerCount('tick')).toBe(0);
+
+    ticker.emit('tick');
+    expect(player.currentTime).toBe(100);
+
+    player.resume();
+    expect(player.state).toBe('playing');
+    expect(ticker.getListenerCount('tick')).toBe(1);
+
+    ticker.emit('tick');
+    expect(player.currentTime).toBe(100);
+
+    ticker.emit('tick');
+    expect(player.currentTime).toBe(150);
+    expect(player.state).toBe('playing');
+    expect(character.tickTo).toHaveBeenCalledWith(150);
+    expect(stateEvents).toEqual(['playing', 'paused', 'playing']);
+  });
+
+  it('should emit end and expose ended state when playback completes', () => {
+    const { story } = createStory();
+    const actionProcessor = createActionProcessor();
+    const player = new Player(story, { actionProcessor });
+    player.initActions(createActions());
+
+    const endEvents: Array<{ currentTime: number; totalTime: number }> = [];
+    player.on('end', event => endEvents.push(event));
+
+    player.play(0);
+    ticker.emit('tick', 100);
+
+    expect(player.state).toBe('ended');
+    expect(player.currentTime).toBe(100);
+    expect(endEvents).toEqual([{ currentTime: 100, totalTime: 100 }]);
+    expect(ticker.getListenerCount('tick')).toBe(0);
   });
 });

--- a/packages/vstory-core/jest.config.js
+++ b/packages/vstory-core/jest.config.js
@@ -1,47 +1,7 @@
-// const path = require('path');
+const base = require('../../share/jest-config/jest.base');
 
-// module.exports = {
-//   runner: 'jest-electron/runner',
-//   testEnvironment: 'jest-electron/environment',
-//   testTimeout: 30000,
-//   testRegex: '/__tests__/.*test\\.ts?$',
-//   moduleFileExtensions: ['ts', 'js', 'json'],
-//   setupFilesAfterEnv: ['jest-extended/all'],
-//   preset: 'ts-jest',
-//   silent: true,
-//   globals: {
-//     'ts-jest': {
-//       resolveJsonModule: true,
-//       esModuleInterop: true,
-//       experimentalDecorators: true,
-//       module: 'ESNext',
-//       tsconfig: './tsconfig.test.json'
-//     },
-//     __DEV__: true
-//   },
-//   setupFiles: ['./setup-mock.js'],
-//   verbose: true,
-//   coverageReporters: ['json-summary', 'lcov', 'text'],
-//   coveragePathIgnorePatterns: ['node_modules', 'demo', 'interface.ts', '.d.ts', 'typings'],
-//   testPathIgnorePatterns: ['demo'],
-//   collectCoverageFrom: [
-//     '**/src/**',
-//     '!**/cjs/**',
-//     '!**/dist/**',
-//     '!**/es/**',
-//     '!**/node_modules/**',
-//     '!**/demo/**',
-//     '!**/interface/**',
-//     '!**/interface.ts',
-//     '!**/**.d.ts'
-//   ],
-//   coverageThreshold: {
-//     global: {
-//       branches: 80,
-//       functions: 80,
-//       lines: 80,
-//       statements: 80
-//     }
-//   },
-//   moduleNameMapper: {}
-// };
+module.exports = {
+  ...base,
+  rootDir: __dirname,
+  setupFiles: ['./setup-mock.js']
+};

--- a/packages/vstory-core/src/core/player.ts
+++ b/packages/vstory-core/src/core/player.ts
@@ -23,7 +23,7 @@ interface IPlayerParams {
 
 export class Player extends EventEmitter implements IPlayer {
   protected _story: IStory | null;
-  protected _ticker: ITicker;
+  protected _ticker: ITicker | null;
   protected _scheduler: IScheduler;
   protected _currTime: number;
   protected _actionProcessor: IActionProcessor;
@@ -115,7 +115,7 @@ export class Player extends EventEmitter implements IPlayer {
 
   reset() {
     this._scheduler.clearState();
-    this._ticker.getTimelines().forEach(tl => tl.clear());
+    this._ticker?.getTimelines().forEach(tl => tl.clear());
     this._currTime = 0;
 
     if (!this._preserveStateOnReset) {
@@ -127,6 +127,10 @@ export class Player extends EventEmitter implements IPlayer {
   }
 
   play(loop: number = 0) {
+    if (this._state !== 'idle' || this._currTime !== 0) {
+      this._resetStoryForRestart();
+    }
+
     const totalTime = this.totalTime;
     this._loop = loop;
     this._currTime = 0;
@@ -139,7 +143,7 @@ export class Player extends EventEmitter implements IPlayer {
       this._finishPlayback();
     } else {
       // 其他环境都需要走ticker
-      this._ticker.start(true);
+      this._ticker?.start(true);
     }
   }
 
@@ -158,7 +162,7 @@ export class Player extends EventEmitter implements IPlayer {
     }
     this._lastFrameTime = -1;
     this._attachTickerListener();
-    this._ticker.start(true);
+    this._ticker?.start(true);
     this._setState('playing');
   }
 
@@ -256,6 +260,18 @@ export class Player extends EventEmitter implements IPlayer {
       totalTime: this.totalTime
     };
     this.emit('stateChange', event);
+  }
+
+  protected _resetStoryForRestart() {
+    if (!this._story) {
+      return;
+    }
+    this._preserveStateOnReset = true;
+    try {
+      this._story.reset();
+    } finally {
+      this._preserveStateOnReset = false;
+    }
   }
 
   protected _finishPlayback() {

--- a/packages/vstory-core/src/core/player.ts
+++ b/packages/vstory-core/src/core/player.ts
@@ -1,5 +1,12 @@
 import type { ITicker } from '@visactor/vrender-core';
-import type { IPlayer, IViewSizeParams } from '../interface/player';
+import { EventEmitter } from '@visactor/vutils';
+import type {
+  IPlayer,
+  IPlayerEndEvent,
+  IPlayerState,
+  IPlayerStateChangeEvent,
+  IViewSizeParams
+} from '../interface/player';
 import type { IStory } from '../interface/story';
 import type { IScheduler } from '../interface/scheduler';
 import { Scheduler } from './scheduler';
@@ -14,34 +21,59 @@ interface IPlayerParams {
   actionProcessor?: IActionProcessor;
 }
 
-export class Player implements IPlayer {
+export class Player extends EventEmitter implements IPlayer {
   protected _story: IStory | null;
   protected _ticker: ITicker;
   protected _scheduler: IScheduler;
   protected _currTime: number;
   protected _actionProcessor: IActionProcessor;
   protected _loop: number;
+  protected _state: IPlayerState;
+  protected _tickerListening: boolean;
+  protected _preserveStateOnReset: boolean;
   protected _lastFrameTime: number = -1;
 
   constructor(story: IStory, params: IPlayerParams = {}) {
+    super();
     const { actionProcessor = new ActionProcessor(story) } = params;
     this._story = story;
     this._ticker = globalTickerStore.getGlobalTicker();
     this._actionProcessor = actionProcessor;
     this._scheduler = new Scheduler(actionProcessor);
     this._currTime = 0;
+    this._loop = 0;
+    this._state = 'idle';
+    this._tickerListening = false;
+    this._preserveStateOnReset = false;
     this.initTicker();
   }
 
+  get state(): IPlayerState {
+    return this._state;
+  }
+
+  get currentTime(): number {
+    return this._currTime;
+  }
+
+  get totalTime(): number {
+    return this._scheduler.getTotalTime();
+  }
+
   initTicker() {
-    this._ticker.addListener('tick', this.handlerTick);
+    this._attachTickerListener();
   }
 
   tickTo(t: number) {
     const lastTime = this._currTime;
     // 如果时间倒退，那就重置，从头开始（需要上层场景树也重置）
     if (lastTime > t) {
-      this._story.reset();
+      this._preserveStateOnReset = true;
+      try {
+        this._story.reset();
+      } finally {
+        this._preserveStateOnReset = false;
+      }
     }
 
     // 初始化 appear 的属性
@@ -85,23 +117,56 @@ export class Player implements IPlayer {
     this._scheduler.clearState();
     this._ticker.getTimelines().forEach(tl => tl.clear());
     this._currTime = 0;
+
+    if (!this._preserveStateOnReset) {
+      this._loop = 0;
+      this._lastFrameTime = -1;
+      this._detachTickerListener();
+      this._setState('idle');
+    }
   }
 
   play(loop: number = 0) {
-    const totalTime = this._scheduler.getTotalTime();
+    const totalTime = this.totalTime;
     this._loop = loop;
+    this._currTime = 0;
+    this._lastFrameTime = -1;
+    this._attachTickerListener();
+    this._setState('playing');
     if (totalTime <= 0 && !this._loop) {
       // 没有动画，且不循环也不持续，直接定位到0s
-      this._currTime = 0;
       this.tickTo(0);
+      this._finishPlayback();
     } else {
       // 其他环境都需要走ticker
-      this._currTime = 0;
       this._ticker.start(true);
     }
   }
 
+  pause() {
+    if (this._state !== 'playing') {
+      return;
+    }
+    this._lastFrameTime = -1;
+    this._detachTickerListener();
+    this._setState('paused');
+  }
+
+  resume() {
+    if (this._state !== 'paused') {
+      return;
+    }
+    this._lastFrameTime = -1;
+    this._attachTickerListener();
+    this._ticker.start(true);
+    this._setState('playing');
+  }
+
   protected handlerTick = (delta?: number) => {
+    if (this._state !== 'playing') {
+      return;
+    }
+
     const time = Date.now();
     if (delta === void 0) {
       if (this._lastFrameTime >= 0) {
@@ -112,28 +177,29 @@ export class Player implements IPlayer {
     }
     this._lastFrameTime = time;
 
-    const totalTime = this._scheduler.getTotalTime();
-    let currTime = this._currTime;
+    const totalTime = this.totalTime;
+    const currTime = this._currTime;
+    let nextTime = currTime + delta;
 
     // 如果是循环播放，_currTime按周期计算
     if (this._loop > 0) {
       if (totalTime <= 0) {
-        currTime = 0;
-      } else {
-        if (currTime + delta > totalTime) {
-          currTime = currTime + delta;
-          while (currTime > totalTime) {
-            currTime = currTime - totalTime;
-          }
-        }
+        nextTime = 0;
+      } else if (nextTime > totalTime) {
+        nextTime = nextTime % totalTime;
       }
     }
 
     if (!this._loop && currTime === totalTime) {
+      this._finishPlayback();
       return;
     }
 
-    this.tickTo(this._loop >= 0 ? Math.min(currTime + delta, totalTime) : currTime + delta);
+    this.tickTo(this._loop >= 0 ? Math.min(nextTime, totalTime) : nextTime);
+
+    if (!this._loop && this._currTime >= totalTime) {
+      this._finishPlayback();
+    }
   };
 
   setViewScale(offsetX: number, offsetY: number, scaleX: number, scaleY: number, params: IViewSizeParams) {
@@ -153,10 +219,56 @@ export class Player implements IPlayer {
   }
 
   release() {
+    this._detachTickerListener();
+    this.removeAllListeners();
     this._actionProcessor.release();
     this._scheduler.release();
-    this._ticker.removeListener('tick', this.handlerTick);
     this._ticker = null;
     // globalTickerStore.releaseGlobalTicker();
+  }
+
+  protected _attachTickerListener() {
+    if (!this._ticker || this._tickerListening) {
+      return;
+    }
+    this._ticker.addListener('tick', this.handlerTick);
+    this._tickerListening = true;
+  }
+
+  protected _detachTickerListener() {
+    if (!this._ticker || !this._tickerListening) {
+      return;
+    }
+    this._ticker.removeListener('tick', this.handlerTick);
+    this._tickerListening = false;
+  }
+
+  protected _setState(state: IPlayerState) {
+    if (this._state === state) {
+      return;
+    }
+    const previousState = this._state;
+    this._state = state;
+    const event: IPlayerStateChangeEvent = {
+      state,
+      previousState,
+      currentTime: this.currentTime,
+      totalTime: this.totalTime
+    };
+    this.emit('stateChange', event);
+  }
+
+  protected _finishPlayback() {
+    if (this._state === 'ended') {
+      return;
+    }
+    this._lastFrameTime = -1;
+    this._detachTickerListener();
+    this._setState('ended');
+    const event: IPlayerEndEvent = {
+      currentTime: this.currentTime,
+      totalTime: this.totalTime
+    };
+    this.emit('end', event);
   }
 }

--- a/packages/vstory-core/src/index.ts
+++ b/packages/vstory-core/src/index.ts
@@ -10,6 +10,7 @@ export * from './interface/action-processor';
 export * from './interface/dsl/dsl';
 export * from './interface/character';
 export * from './interface/story';
+export * from './interface/player';
 export * from './interface/event';
 export * from './interface/plugin-service';
 export * from './interface/releaseable';

--- a/packages/vstory-core/src/interface/player.ts
+++ b/packages/vstory-core/src/interface/player.ts
@@ -1,3 +1,4 @@
+import type { EventEmitter } from '@visactor/vutils';
 import type { IActionSpec, IActSpec } from './dsl/dsl';
 import type { IReleaseable } from './releaseable';
 import type { IStory } from './story';
@@ -6,7 +7,21 @@ export interface IViewSizeParams {
   keepFrame?: boolean; // 是否保持画幅不变，如果正常情况下是裁剪了，那么缩放后裁剪的地方依然不显示
 }
 
-export interface IPlayer extends IReleaseable {
+export type IPlayerState = 'idle' | 'playing' | 'paused' | 'ended';
+
+export interface IPlayerStateChangeEvent {
+  state: IPlayerState;
+  previousState: IPlayerState;
+  currentTime: number;
+  totalTime: number;
+}
+
+export interface IPlayerEndEvent {
+  currentTime: number;
+  totalTime: number;
+}
+
+export interface IPlayer extends IReleaseable, EventEmitter {
   bindStory: (story: IStory) => void;
   tickTo: (t: number) => void;
 
@@ -16,6 +31,12 @@ export interface IPlayer extends IReleaseable {
   setViewScale: (offsetX: number, offsetY: number, scaleX: number, scaleY: number, params: IViewSizeParams) => void;
   // loop小于0的话，不循环持续播放，loop等于0的话，仅放一次，loop大于0的话，持续循环播放
   play: (loop?: number) => void;
+  pause: () => void;
+  resume: () => void;
+
+  readonly state: IPlayerState;
+  readonly currentTime: number;
+  readonly totalTime: number;
 
   reset: () => void;
 


### PR DESCRIPTION
## Summary
- add public `pause()` and `resume()` APIs to `Player`
- expose playback state, current time, total time, and `stateChange`/`end` events
- add `@visactor/vstory-core` tests and enable package-level `ts-jest` so the new tests run in CI/hooks
- document the new player APIs in the English and Chinese guides

## Testing
- `pnpm --dir packages/vstory-core exec jest __tests__/unit/index.test.ts --runInBand`
- `pnpm --dir packages/vstory-core exec tsc --noEmit -p tsconfig.json`
- `git push -u origin issue-294-player-pause-resume` (`pre-push` ran `rush test --only tag:package` successfully)

Closes #294