### PR TITLE
fix: replace removed getAllElements API with forEachChildren in WaveScatter

### DIFF
--- a/packages/vstory-player/src/processor/chart/waveScatter/visibility.ts
+++ b/packages/vstory-player/src/processor/chart/waveScatter/visibility.ts
@@ -27,7 +27,12 @@ export class WaveScatterVisibilityActionProcessor extends VChartVisibilityAction
     }
     const { duration, easing, loop, custom } = waveAnimate;
     const product = mark.getProduct();
-    const graphics = product.getAllElements().map((item: any) => item.getGraphicItem());
+    const graphics: any[] = [];
+    if (product && typeof (product as any).forEachChildren === 'function') {
+      (product as any).forEachChildren((child: any) => {
+        graphics.push(child);
+      });
+    }
     if (!graphics.length) {
       return;
     }


### PR DESCRIPTION
## Problem

WaveScatter character crashes on `appear` action with:

```
TypeError: mark.getProduct(...).getAllElements is not a function
```

## Root Cause

`mark.getProduct()` now returns VRender `IGroup`, which does not have the old VGrammar `getAllElements()` method.

## Fix

Replace `product.getAllElements().map(item => item.getGraphicItem())` with `product.forEachChildren()` to collect child graphics directly from the group — consistent with how the base `VChartVisibilityActionProcessor` already iterates over group children.