### PR TITLE
fix: generalize getFinalAttribute fallback to all mark types to fix line growPoints crash

### DIFF
--- a/packages/vstory-player/__tests__/unit/index.test.ts
+++ b/packages/vstory-player/__tests__/unit/index.test.ts
@@ -74,4 +74,43 @@ describe('VChartVisibilityActionProcessor', () => {
     expect(product.executeAnimation).toHaveBeenCalledWith({ type: 'growHeightIn' });
     expect(product.getFinalAttribute()).toEqual(product.attribute);
   });
+
+  it('should patch line graphic final attrs to prevent growPoints crash', () => {
+    const childLine = {
+      type: 'line',
+      attribute: {
+        points: [
+          { x: 0, y: 100 },
+          { x: 50, y: 50 },
+          { x: 100, y: 80 }
+        ]
+      },
+      getFinalAttribute: jest.fn(() => undefined)
+    };
+    const product = {
+      type: 'group',
+      setAttribute: jest.fn(),
+      executeAnimation: jest.fn(),
+      forEachChildren: (cb: any) => cb(childLine, 0)
+    };
+    const mark = {
+      type: 'line',
+      getProduct: () => product
+    };
+    const series = {
+      getMarksWithoutRoot: () => [mark]
+    };
+    const processor = new VChartVisibilityActionProcessor();
+
+    jest.spyOn(processor, 'getMarkAnimateConfig').mockReturnValue({ type: 'growPointsYIn' });
+
+    (processor as any).commonSeriesAppear({}, series, 'appear', createPayload(), true);
+
+    expect(product.executeAnimation).toHaveBeenCalledWith({ type: 'growPointsYIn' });
+    // After patching, getFinalAttribute should fall back to attribute (which has points)
+    const finalAttr = childLine.getFinalAttribute();
+    expect(finalAttr).toEqual(childLine.attribute);
+    expect(finalAttr.points).toBeDefined();
+    expect(finalAttr.points).toHaveLength(3);
+  });
 });

--- a/packages/vstory-player/src/processor/chart/visibility.ts
+++ b/packages/vstory-player/src/processor/chart/visibility.ts
@@ -277,9 +277,7 @@ export class VChartVisibilityActionProcessor extends VChartBaseActionProcessor {
       const config = this.getMarkAnimateConfig(vchart, mark, markIndex, action, series, payload);
       const product = mark.getProduct();
       if (isRun) {
-        if (mark.type === 'rect' || mark.type === 'rect3d') {
-          this.ensureRectMarkFinalAttributes(product as IGraphic | IGroup | null);
-        }
+        this.ensureMarkFinalAttributes(product as IGraphic | IGroup | null);
         product?.setAttribute?.('visibleAll', true);
         (product as any)?.executeAnimation?.(config || {});
       } else {
@@ -319,7 +317,7 @@ export class VChartVisibilityActionProcessor extends VChartBaseActionProcessor {
     );
   }
 
-  private ensureRectMarkFinalAttributes(graphic: IGraphic | IGroup | null | undefined) {
+  private ensureMarkFinalAttributes(graphic: IGraphic | IGroup | null | undefined) {
     if (!graphic) {
       return;
     }
@@ -330,13 +328,11 @@ export class VChartVisibilityActionProcessor extends VChartBaseActionProcessor {
       __vstoryGetFinalAttributeFallbackPatched?: boolean;
     };
 
-    if (targetGraphic.type === 'rect' || targetGraphic.type === 'rect3d') {
-      this.patchGraphicFinalAttribute(targetGraphic);
-    }
+    this.patchGraphicFinalAttribute(targetGraphic);
 
     if (typeof targetGraphic.forEachChildren === 'function') {
       targetGraphic.forEachChildren(child => {
-        this.ensureRectMarkFinalAttributes(child as IGraphic | IGroup);
+        this.ensureMarkFinalAttributes(child as IGraphic | IGroup);
       });
     }
   }


### PR DESCRIPTION
## Problem

Line charts using the `growPoints` animation effect crash with:

```
TypeError: Cannot read properties of undefined (reading 'points')
```

This happens because `getFinalAttribute()` returns `undefined` for line graphics, and the VRender animation code (`growPointsYIn`/`growPointsXIn`) accesses `.points` on the result without null-checking.

## Root Cause

The `ensureRectMarkFinalAttributes` method (introduced in PR #300) only patched `rect` and `rect3d` graphics with a `getFinalAttribute()` fallback. Line, area, and polygon graphics were not covered, causing `growPoints` animations to crash.

## Fix

- Renamed `ensureRectMarkFinalAttributes` → `ensureMarkFinalAttributes`
- Removed the type restriction so the `getFinalAttribute()` fallback patch applies to **all** graphic types
- The patch is universally safe — it only adds a fallback to `graphic.attribute` when `getFinalAttribute()` returns null/undefined
- Added a unit test specifically for line graphic patching

## Changes

- `packages/vstory-player/src/processor/chart/visibility.ts`: Generalized patching to all mark types
- `packages/vstory-player/__tests__/unit/index.test.ts`: Added test for line graphic case