### PR TITLE
fix(workflow): restore sync trigger after release

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -1,7 +1,7 @@
 name: Sync main to develop after release
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:


### PR DESCRIPTION
## Summary
Restore the automatic main-to-develop sync workflow after release PR merges.

## Root cause
The release workflow now creates release branch commits with [skip ci], which causes pull_request-based workflows to be skipped when the release PR is merged.

## Change
Switch sync-main-to-develop from pull_request to pull_request_target so closed release PR merges into main still trigger the sync workflow.